### PR TITLE
More clear message for all errors

### DIFF
--- a/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
@@ -39,7 +39,7 @@ class PickleProcessor : AbstractProcessor() {
             }
         } catch (exception: Exception) {
             processingEnv.messager.error("""
-                Pickler Error:
+                Pickle Error:
                 ${exception.message}
             """.trimIndent())
         } finally {

--- a/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
@@ -38,7 +38,10 @@ class PickleProcessor : AbstractProcessor() {
                         .forEach { writer.write(it) }
             }
         } catch (exception: Exception) {
-            processingEnv.messager.error(exception.message!!)
+            processingEnv.messager.error("""
+                Pickler Error:
+                ${exception.message}
+            """.trimIndent())
         } finally {
             return false
         }


### PR DESCRIPTION
Prefix all exceptions with "Pickle Error:"
Look like this:

```
error: Pickle Error:
  Missing step definition for "foo step"
2 errors
```

instead of:

```
error: Missing step definition for "foo step"
2 errors
```