### PR TITLE
Detect mismatch of arguments in the method and regex

### DIFF
--- a/processor/src/main/java/com/fourlastor/pickle/MethodConverter.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/MethodConverter.kt
@@ -24,4 +24,4 @@ class MethodConverter(
     }
 }
 
-private fun CucumberScenario.stepsIncludingBackground() = (cucumberBackground?.steps ?: emptyList()) + steps
+private fun CucumberScenario.stepsIncludingBackground() = (cucumberBackground?.steps.orEmpty()) + steps

--- a/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
@@ -16,17 +16,8 @@ class PickleProcessor : AbstractProcessor() {
 
         try {
             options(roundEnv).run {
-
                 val parser = FeatureParser()
-                val classConverter = ClassConverter(
-                        MethodsConverter(
-                                MethodConverter(
-                                        StatementConverter(roundEnv),
-                                        StatementHooksCreator(roundEnv)
-                                ),
-                                strictMode
-                        )
-                )
+                val classConverter = createClassConverter(roundEnv)
 
                 val generator = ClassGenerator()
                 val writer = ClassWriter(processingEnv, packageName)
@@ -42,6 +33,18 @@ class PickleProcessor : AbstractProcessor() {
         } finally {
             return false
         }
+    }
+
+    private fun Options.createClassConverter(roundEnv: RoundEnvironment): ClassConverter {
+        return ClassConverter(
+                MethodsConverter(
+                        MethodConverter(
+                                StatementConverter(roundEnv),
+                                StatementHooksCreator(roundEnv)
+                        ),
+                        strictMode
+                )
+        )
     }
 
     private fun Messager.error(message: String) {

--- a/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
@@ -22,7 +22,7 @@ class StatementHooksCreator(private val roundEnv: RoundEnvironment) {
 
         return methodStatements.flatMap { (field) ->
             methods.filter { method -> field.type.toString() == method.enclosingElement.asType().toString() }
-                    .map { method -> testMethodStatement(field, "\$N.\$N()", field.name, method.simpleName) }
+                    .map { method -> testMethodStatement(field, "\$N.\$N()", method.simpleName) }
         }.toSet()
     }
 }

--- a/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
@@ -1,5 +1,6 @@
 package com.fourlastor.pickle
 
+import javax.lang.model.element.Name
 import javax.lang.model.element.TypeElement
 
 data class TestClass(val name: String, val methods: List<TestMethod>, val fields: Set<TestField>)
@@ -10,5 +11,5 @@ data class TestField(val type: TypeElement) {
             get() = type.qualifiedName.toString().decapitalize().replace('.', '_')
 }
 
-fun testMethodStatement(field: TestField, statementFormat: String, vararg args: Any) =
-        TestMethodStatement(field, statementFormat, args.asList())
+fun testMethodStatement(testField: TestField, statementFormat: String, methodName: Name, vararg args: Any) =
+        TestMethodStatement(testField, statementFormat, listOf(testField.name, methodName) + args)


### PR DESCRIPTION
Detect mismatch of arguments in the method and regex

Here is the error:

```
error: Step definition argument mismatch.
  > Step definition: "submit incorrect password"
  > Step implementation: com.example.steps.login.LoginSteps.submitsIncorrectPassword(java.lang.String)
2 errors
```

Before it was: 

```
error: index 3 for '$S' not in range (received 2 arguments)
```

Fixes #5 