### PR TITLE
Quick fix for Gradle 5.2 crash

### DIFF
--- a/plugin/src/main/java/com/fourlastor/pickle/PicklePlugin.kt
+++ b/plugin/src/main/java/com/fourlastor/pickle/PicklePlugin.kt
@@ -139,7 +139,7 @@ class PicklePlugin : Plugin<Project> {
             val mergeAssets = method(taskProvider, MergeSourceSetFolders::class.java, "get").invoke(taskProvider)
             val outputDirProvider = method(mergeAssets, Provider::class.java, "getOutputDir").invoke(mergeAssets)
             (outputDirProvider.get() as Directory).asFile
-        } catch (ignored: Exception) {
+        } catch (ignored: Throwable) {
             mergeAssets.outputDir
         }
     }
@@ -154,7 +154,7 @@ class PicklePlugin : Plugin<Project> {
     private fun setupDependency(task: GenerateTask, variant: TestVariant) {
         try {
             task.dependsOn(variant.mergeAssetsProvider)
-        } catch (ignored: Exception) {
+        } catch (ignored: Throwable) {
             task.dependsOn(variant.mergeAssets)
         }
     }


### PR DESCRIPTION
Catch Throwable instead of Exception to catch that `method` is removed. This will at least fix the crash. 

The real solution would be to replace `JavaReflectionUtil.method` with regular reflection.

This change will at least make the plugin compatible for Android Studio 3.3 and Gradle 5.2+