### PR TITLE
Re-work hook handling

### DIFF
--- a/processor/src/main/java/com/fourlastor/pickle/ClassConverter.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/ClassConverter.kt
@@ -4,23 +4,21 @@ import cucumber.runtime.model.CucumberFeature
 
 class ClassConverter(
         private val methodsConverter: MethodsConverter,
-        private val statementHooksCreator: StatementHooksCreator
+        private val hooksCreator: HooksCreator
 ) {
 
     fun convert(feature: CucumberFeature): TestClass {
         val methods = methodsConverter.convert(feature.featureElements)
-        val before = beforeHookMethod(statementHooksCreator.createBeforeHooks())
-        val after = afterHookMethod(statementHooksCreator.createAfterHooks())
+        val hooks = hooksCreator.create()
 
         val fields = methods.flatMap { it.statements }
-                .plus(before.statements)
-                .plus(after.statements)
+                .plus(hooks.flatMap { it.statements })
                 .map { it.field }
                 .toSet()
 
         return TestClass(
                 "${feature.gherkinFeature.name.toCamelCase()}Test",
-                listOf(before, after),
+                hooks,
                 methods,
                 fields
         )

--- a/processor/src/main/java/com/fourlastor/pickle/ClassConverter.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/ClassConverter.kt
@@ -2,14 +2,25 @@ package com.fourlastor.pickle
 
 import cucumber.runtime.model.CucumberFeature
 
-class ClassConverter(private val methodsConverter: MethodsConverter) {
+class ClassConverter(
+        private val methodsConverter: MethodsConverter,
+        private val statementHooksCreator: StatementHooksCreator
+) {
 
     fun convert(feature: CucumberFeature): TestClass {
         val methods = methodsConverter.convert(feature.featureElements)
-        val fields = methods.flatMap { it.statements.map { it.field } }.toSet()
+        val before = beforeHookMethod(statementHooksCreator.createBeforeHooks())
+        val after = afterHookMethod(statementHooksCreator.createAfterHooks())
+
+        val fields = methods.flatMap { it.statements }
+                .plus(before.statements)
+                .plus(after.statements)
+                .map { it.field }
+                .toSet()
 
         return TestClass(
                 "${feature.gherkinFeature.name.toCamelCase()}Test",
+                listOf(before, after),
                 methods,
                 fields
         )

--- a/processor/src/main/java/com/fourlastor/pickle/ClassGenerator.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/ClassGenerator.kt
@@ -18,15 +18,31 @@ class ClassGenerator {
         runWithJUnit4()
         addModifiers(Modifier.PUBLIC)
 
-        testClass.methods.forEach {
-            method(it.name) {
+        testClass.hookMethods
+                .filter { it.statements.isNotEmpty() }
+                .forEach { hook ->
+                    method(hook.name) {
+                        addModifiers(Modifier.PUBLIC)
+                        addException(Throwable::class.java)
+                        addAnnotation(hook.annotation)
+
+                        code {
+                            hook.statements.forEach {
+                                addStatement(it.statementFormat, *it.args.toTypedArray())
+                            }
+                        }
+                    }
+                }
+
+        testClass.methods.forEach { method ->
+            method(method.name) {
 
                 addModifiers(Modifier.PUBLIC)
                 addException(Throwable::class.java)
                 addAnnotation(Test)
 
                 code {
-                    it.statements.forEach {
+                    method.statements.forEach {
                         addStatement(it.statementFormat, *it.args.toTypedArray())
                     }
                 }

--- a/processor/src/main/java/com/fourlastor/pickle/HooksCreator.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/HooksCreator.kt
@@ -1,0 +1,20 @@
+package com.fourlastor.pickle
+
+import com.squareup.javapoet.ClassName
+
+class HooksCreator(private val statementHooksCreator: StatementHooksCreator) {
+
+    fun create(): List<HookMethod> {
+        val before = beforeHookMethod(statementHooksCreator.createBeforeHooks())
+        val after = afterHookMethod(statementHooksCreator.createAfterHooks())
+
+        return listOf(before, after)
+    }
+
+    private fun beforeHookMethod(statements: List<TestMethodStatement>) =
+            HookMethod(ClassName.bestGuess("org.junit.Before")!!, "setUp", statements)
+
+    private fun afterHookMethod(statements: List<TestMethodStatement>) =
+            HookMethod(ClassName.bestGuess("org.junit.After")!!, "tearDown", statements)
+
+}

--- a/processor/src/main/java/com/fourlastor/pickle/MethodConverter.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/MethodConverter.kt
@@ -2,10 +2,7 @@ package com.fourlastor.pickle
 
 import cucumber.runtime.model.CucumberScenario
 
-class MethodConverter(
-        private val statementConverter: StatementConverter,
-        private val statementHooksCreator: StatementHooksCreator
-) {
+class MethodConverter(private val statementConverter: StatementConverter) {
 
     fun convert(name: String, scenario: CucumberScenario): TestMethod {
         val statements = createStatementsFor(scenario)

--- a/processor/src/main/java/com/fourlastor/pickle/MethodConverter.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/MethodConverter.kt
@@ -12,16 +12,10 @@ class MethodConverter(
         return TestMethod(name, statements)
     }
 
-    private fun createStatementsFor(scenario: CucumberScenario): Set<TestMethodStatement> {
-        val methodStatements = scenario.stepsIncludingBackground()
+    private fun createStatementsFor(scenario: CucumberScenario): List<TestMethodStatement> {
+        return scenario.stepsIncludingBackground()
                 .map { statementConverter.convert(it) }
-
-        val beforeStatements = statementHooksCreator.createBeforeHooks(methodStatements)
-
-        val afterStatements = statementHooksCreator.createAfterHooks(methodStatements)
-
-        return beforeStatements + methodStatements + afterStatements
     }
 }
 
-private fun CucumberScenario.stepsIncludingBackground() = (cucumberBackground?.steps.orEmpty()) + steps
+private fun CucumberScenario.stepsIncludingBackground() = cucumberBackground?.steps.orEmpty() + steps

--- a/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
@@ -1,6 +1,10 @@
 package com.fourlastor.pickle
 
-import javax.annotation.processing.*
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.Messager
+import javax.annotation.processing.RoundEnvironment
+import javax.annotation.processing.SupportedAnnotationTypes
+import javax.annotation.processing.SupportedSourceVersion
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.tools.Diagnostic
@@ -41,13 +45,11 @@ class PickleProcessor : AbstractProcessor() {
     private fun Options.createClassConverter(roundEnv: RoundEnvironment, messager: Messager): ClassConverter {
         return ClassConverter(
                 MethodsConverter(
-                        MethodConverter(
-                                StatementConverter(roundEnv),
-                                StatementHooksCreator(roundEnv)
-                        ),
+                        MethodConverter(StatementConverter(roundEnv)),
                         strictMode,
                         messager
-                )
+                ),
+                StatementHooksCreator(roundEnv)
         )
     }
 

--- a/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
@@ -49,7 +49,7 @@ class PickleProcessor : AbstractProcessor() {
                         strictMode,
                         messager
                 ),
-                StatementHooksCreator(roundEnv)
+                HooksCreator(StatementHooksCreator(roundEnv))
         )
     }
 

--- a/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
@@ -32,11 +32,9 @@ class StatementHooksCreator(private val roundEnv: RoundEnvironment) {
             when (val annotation = getAnnotation(annotationType)) {
                 is Before -> annotation.order
                 is After -> annotation.order
-                else -> DEFAULT_CUCUMBER_HOOK_ORDER
+                else -> throw IllegalStateException("Unexpected Cucumber annotation used: $annotationType")
             }
 }
-
-private const val DEFAULT_CUCUMBER_HOOK_ORDER = 10000
 
 private fun <T : Annotation> RoundEnvironment.getMethodsAnnotatedWith(clazz: Class<T>): List<ExecutableElement> {
     return getElementsAnnotatedWith(clazz)

--- a/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
@@ -15,17 +15,28 @@ class StatementHooksCreator(private val roundEnv: RoundEnvironment) {
             generateStatementsFor(After::class.java, roundEnv)
 
     private fun generateStatementsFor(
-            annotation: Class<out Annotation>,
+            annotationType: Class<out Annotation>,
             roundEnv: RoundEnvironment
     ): List<TestMethodStatement> {
-        val methods = roundEnv.getMethodsAnnotatedWith(annotation)
+        val methods = roundEnv.getMethodsAnnotatedWith(annotationType)
 
-        return methods.map { method ->
+        return methods.sortedBy {
+            it.annotationOrder(annotationType)
+        }.map { method ->
             val field = TestField(method.enclosingElement as TypeElement)
             testMethodStatement(field, "\$N.\$N()", method.simpleName)
         }
     }
+
+    private fun ExecutableElement.annotationOrder(annotationType: Class<out Annotation>) =
+            when (val annotation = getAnnotation(annotationType)) {
+                is Before -> annotation.order
+                is After -> annotation.order
+                else -> DEFAULT_CUCUMBER_HOOK_ORDER
+            }
 }
+
+private const val DEFAULT_CUCUMBER_HOOK_ORDER = 10000
 
 private fun <T : Annotation> RoundEnvironment.getMethodsAnnotatedWith(clazz: Class<T>): List<ExecutableElement> {
     return getElementsAnnotatedWith(clazz)

--- a/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
@@ -5,25 +5,25 @@ import cucumber.api.java.Before
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.TypeElement
 
 class StatementHooksCreator(private val roundEnv: RoundEnvironment) {
-    fun createBeforeHooks(methodStatements: List<TestMethodStatement>): Set<TestMethodStatement> =
-            generateStatementsFor(Before::class.java, roundEnv, methodStatements)
+    fun createBeforeHooks(): List<TestMethodStatement> =
+            generateStatementsFor(Before::class.java, roundEnv)
 
-    fun createAfterHooks(methodStatements: List<TestMethodStatement>): Set<TestMethodStatement> =
-            generateStatementsFor(After::class.java, roundEnv, methodStatements)
+    fun createAfterHooks(): List<TestMethodStatement> =
+            generateStatementsFor(After::class.java, roundEnv)
 
     private fun generateStatementsFor(
             annotation: Class<out Annotation>,
-            roundEnv: RoundEnvironment,
-            methodStatements: List<TestMethodStatement>
-    ): Set<TestMethodStatement> {
+            roundEnv: RoundEnvironment
+    ): List<TestMethodStatement> {
         val methods = roundEnv.getMethodsAnnotatedWith(annotation)
 
-        return methodStatements.flatMap { (field) ->
-            methods.filter { method -> field.type.toString() == method.enclosingElement.asType().toString() }
-                    .map { method -> testMethodStatement(field, "\$N.\$N()", method.simpleName) }
-        }.toSet()
+        return methods.map { method ->
+            val field = TestField(method.enclosingElement as TypeElement)
+            testMethodStatement(field, "\$N.\$N()", method.simpleName)
+        }
     }
 }
 

--- a/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
@@ -4,7 +4,7 @@ import javax.lang.model.element.Name
 import javax.lang.model.element.TypeElement
 
 data class TestClass(val name: String, val methods: List<TestMethod>, val fields: Set<TestField>)
-data class TestMethod(val name: String, val statements: Set<TestMethodStatement>)
+data class TestMethod(val name: String, val statements: List<TestMethodStatement>)
 data class TestMethodStatement(val field: TestField, val statementFormat: String, val args: List<Any>)
 data class TestField(val type: TypeElement) {
     val name: String

--- a/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
@@ -21,9 +21,3 @@ data class TestField(val type: TypeElement) {
 
 fun testMethodStatement(testField: TestField, statementFormat: String, methodName: Name, vararg args: Any) =
         TestMethodStatement(testField, statementFormat, listOf(testField.name, methodName) + args)
-
-fun beforeHookMethod(statements: List<TestMethodStatement>) =
-        HookMethod(ClassName.bestGuess("org.junit.Before")!!, "setUp", statements)
-
-fun afterHookMethod(statements: List<TestMethodStatement>) =
-        HookMethod(ClassName.bestGuess("org.junit.After")!!, "tearDown", statements)

--- a/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
+++ b/processor/src/main/java/com/fourlastor/pickle/TestClass.kt
@@ -1,15 +1,29 @@
 package com.fourlastor.pickle
 
+import com.squareup.javapoet.ClassName
 import javax.lang.model.element.Name
 import javax.lang.model.element.TypeElement
 
-data class TestClass(val name: String, val methods: List<TestMethod>, val fields: Set<TestField>)
+data class TestClass(
+        val name: String,
+        val hookMethods: List<HookMethod>,
+        val methods: List<TestMethod>,
+        val fields: Set<TestField>
+)
+
+data class HookMethod(val annotation: ClassName, val name: String, val statements: List<TestMethodStatement>)
 data class TestMethod(val name: String, val statements: List<TestMethodStatement>)
 data class TestMethodStatement(val field: TestField, val statementFormat: String, val args: List<Any>)
 data class TestField(val type: TypeElement) {
     val name: String
-            get() = type.qualifiedName.toString().decapitalize().replace('.', '_')
+        get() = type.qualifiedName.toString().decapitalize().replace('.', '_')
 }
 
 fun testMethodStatement(testField: TestField, statementFormat: String, methodName: Name, vararg args: Any) =
         TestMethodStatement(testField, statementFormat, listOf(testField.name, methodName) + args)
+
+fun beforeHookMethod(statements: List<TestMethodStatement>) =
+        HookMethod(ClassName.bestGuess("org.junit.Before")!!, "setUp", statements)
+
+fun afterHookMethod(statements: List<TestMethodStatement>) =
+        HookMethod(ClassName.bestGuess("org.junit.After")!!, "tearDown", statements)

--- a/processor/src/test/java/com/fourlastor/pickle/PickleTest.kt
+++ b/processor/src/test/java/com/fourlastor/pickle/PickleTest.kt
@@ -93,7 +93,7 @@ class PickleTest {
                 featuresDir,
                 packageName,
                 strict,
-                "steps/Steps.java", "steps/OtherSteps.java"//, "steps/JustHooks.java"
+                "steps/Steps.java", "steps/OtherSteps.java", "steps/JustHooks.java"
         )
 
         assertThat(compilation).successfullyGeneratedTestClasses(

--- a/processor/src/test/java/com/fourlastor/pickle/PickleTest.kt
+++ b/processor/src/test/java/com/fourlastor/pickle/PickleTest.kt
@@ -87,6 +87,22 @@ class PickleTest {
     }
 
     @Test
+    fun featureWithDefinedStepsAndHooksFromSeparateFile() {
+        val packageName = "targetWithSeparateHooks"
+        val compilation = whenCompilingWith(
+                featuresDir,
+                packageName,
+                strict,
+                "steps/Steps.java", "steps/OtherSteps.java"//, "steps/JustHooks.java"
+        )
+
+        assertThat(compilation).successfullyGeneratedTestClasses(
+                "$packageName/AFeatureWithoutBackgroundTest.java",
+                "$packageName/AFeatureWithBackgroundTest.java"
+        )
+    }
+
+    @Test
     fun featureWithDuplicateScenarios() {
         val compilation = whenCompilingWith(
                 featuresDir("featuresDuplicateScenario"),

--- a/processor/src/test/resources/steps/JustHooks.java
+++ b/processor/src/test/resources/steps/JustHooks.java
@@ -1,0 +1,18 @@
+package steps;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+
+public class JustHooks {
+
+    @Before
+    public void beforeHook() {
+
+    }
+
+    @After
+    public void afterHook() {
+
+    }
+
+}

--- a/processor/src/test/resources/targetWithHooks/AFeatureWithBackgroundTest.java
+++ b/processor/src/test/resources/targetWithHooks/AFeatureWithBackgroundTest.java
@@ -2,6 +2,8 @@ package targetWithHooks;
 
 import android.support.test.runner.AndroidJUnit4;
 import java.lang.Throwable;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.OtherStepsWithHooks;
@@ -12,6 +14,16 @@ public class AFeatureWithBackgroundTest {
     private final Steps steps_Steps = new Steps();
 
     private final OtherStepsWithHooks steps_OtherStepsWithHooks = new OtherStepsWithHooks();
+
+    @Before
+    public void setUp() throws Throwable {
+        steps_OtherStepsWithHooks.beforeHook();
+    }
+
+    @After
+    public void tearDown() throws Throwable {
+        steps_OtherStepsWithHooks.afterHook();
+    }
 
     @Test
     public void scenarioWithOneStepAndBackground() throws Throwable {

--- a/processor/src/test/resources/targetWithHooks/AFeatureWithoutBackgroundTest.java
+++ b/processor/src/test/resources/targetWithHooks/AFeatureWithoutBackgroundTest.java
@@ -2,6 +2,8 @@ package targetWithHooks;
 
 import android.support.test.runner.AndroidJUnit4;
 import java.lang.Throwable;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.OtherStepsWithHooks;
@@ -12,6 +14,16 @@ public class AFeatureWithoutBackgroundTest {
     private final Steps steps_Steps = new Steps();
 
     private final OtherStepsWithHooks steps_OtherStepsWithHooks = new OtherStepsWithHooks();
+
+    @Before
+    public void setUp() throws Throwable {
+        steps_OtherStepsWithHooks.beforeHook();
+    }
+
+    @After
+    public void tearDown() throws Throwable {
+        steps_OtherStepsWithHooks.afterHook();
+    }
 
     @Test
     public void scenarioWithOneStepAlsoNonAlphanumericChars_1() throws Throwable {

--- a/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithBackgroundTest.java
+++ b/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithBackgroundTest.java
@@ -2,8 +2,11 @@ package targetWithSeparateHooks;
 
 import android.support.test.runner.AndroidJUnit4;
 import java.lang.Throwable;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import steps.JustHooks;
 import steps.OtherSteps;
 import steps.Steps;
 
@@ -12,6 +15,17 @@ public class AFeatureWithBackgroundTest {
 
     private final Steps steps_Steps = new Steps();
     private final OtherSteps steps_OtherSteps = new OtherSteps();
+    private final JustHooks steps_JustHooks = new JustHooks();
+
+    @Before
+    public void setUp() throws Throwable {
+        steps_JustHooks.beforeHook();
+    }
+
+    @After
+    public void tearDown() throws Throwable {
+        steps_JustHooks.afterHook();
+    }
 
     @Test
     public void scenarioWithOneStepAndBackground() throws Throwable {

--- a/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithBackgroundTest.java
+++ b/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithBackgroundTest.java
@@ -1,21 +1,21 @@
-package targetWithHooks;
+package targetWithSeparateHooks;
 
 import android.support.test.runner.AndroidJUnit4;
 import java.lang.Throwable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import steps.OtherStepsWithHooks;
+import steps.OtherSteps;
 import steps.Steps;
 
 @RunWith(AndroidJUnit4.class)
 public class AFeatureWithBackgroundTest {
-    private final Steps steps_Steps = new Steps();
 
-    private final OtherStepsWithHooks steps_OtherStepsWithHooks = new OtherStepsWithHooks();
+    private final Steps steps_Steps = new Steps();
+    private final OtherSteps steps_OtherSteps = new OtherSteps();
 
     @Test
     public void scenarioWithOneStepAndBackground() throws Throwable {
         steps_Steps.aStepWithoutParameters();
-        steps_OtherStepsWithHooks.aStepFromAnotherDefinitionFile();
+        steps_OtherSteps.aStepFromAnotherDefinitionFile();
     }
 }

--- a/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithoutBackgroundTest.java
+++ b/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithoutBackgroundTest.java
@@ -2,8 +2,11 @@ package targetWithSeparateHooks;
 
 import android.support.test.runner.AndroidJUnit4;
 import java.lang.Throwable;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import steps.JustHooks;
 import steps.OtherSteps;
 import steps.Steps;
 
@@ -12,6 +15,17 @@ public class AFeatureWithoutBackgroundTest {
 
     private final Steps steps_Steps = new Steps();
     private final OtherSteps steps_OtherSteps = new OtherSteps();
+    private final JustHooks steps_JustHooks = new JustHooks();
+
+    @Before
+    public void setUp() throws Throwable {
+        steps_JustHooks.beforeHook();
+    }
+
+    @After
+    public void tearDown() throws Throwable {
+        steps_JustHooks.afterHook();
+    }
 
     @Test
     public void scenarioWithOneStepAlsoNonAlphanumericChars_1() throws Throwable {

--- a/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithoutBackgroundTest.java
+++ b/processor/src/test/resources/targetWithSeparateHooks/AFeatureWithoutBackgroundTest.java
@@ -1,17 +1,17 @@
-package targetWithHooks;
+package targetWithSeparateHooks;
 
 import android.support.test.runner.AndroidJUnit4;
 import java.lang.Throwable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import steps.OtherStepsWithHooks;
+import steps.OtherSteps;
 import steps.Steps;
 
 @RunWith(AndroidJUnit4.class)
 public class AFeatureWithoutBackgroundTest {
-    private final Steps steps_Steps = new Steps();
 
-    private final OtherStepsWithHooks steps_OtherStepsWithHooks = new OtherStepsWithHooks();
+    private final Steps steps_Steps = new Steps();
+    private final OtherSteps steps_OtherSteps = new OtherSteps();
 
     @Test
     public void scenarioWithOneStepAlsoNonAlphanumericChars_1() throws Throwable {
@@ -27,7 +27,7 @@ public class AFeatureWithoutBackgroundTest {
     @Test
     public void scenarioWithStepsFrom2DefinitionFiles() throws Throwable {
         steps_Steps.aStepWithoutParameters();
-        steps_OtherStepsWithHooks.aStepFromAnotherDefinitionFile();
+        steps_OtherSteps.aStepFromAnotherDefinitionFile();
     }
 
     @Test


### PR DESCRIPTION
As described more in #26 and can be seen in the changes to the test fixtures, the hook handling was not working as expected. 

The initial problem that I got was that "@After hook was not called when tests fail". I thought of various ways to fix this but the easiest/safest way was to use JUnit's `Before` and `After` annotation after all.

Also, if you look closely into official documentation, it says that the scenario hooks are run on every scenario regardless of where they were put. https://docs.cucumber.io/cucumber/api/#scenario-hooks

Additional details:

- Also used this opportunity use Cucumber hooks' order to sort the method call order.
- Wrote a new test that shows that we are able to pickup hooks from separate files.

Fixes #26 