### PR TITLE
Do not ignore crashes by only handling PickleException

### DIFF
--- a/pickle-processor/src/main/java/com/fourlastor/pickle/ClassGenerator.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/ClassGenerator.kt
@@ -78,4 +78,4 @@ class ClassGenerator {
     }
 }
 
-class MissingStepDefinitionException(stepName: String) : RuntimeException("Missing step definition for \"$stepName\"")
+class MissingStepDefinitionException(stepName: String) : PickleException("Missing step definition for \"$stepName\"")

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/FeatureParser.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/FeatureParser.kt
@@ -21,4 +21,4 @@ class FeatureParser {
     }
 }
 
-class FeatureFilesPathIsNotDirectoryException(path: String) : RuntimeException("$path is not a directory")
+class FeatureFilesPathIsNotDirectoryException(path: String) : PickleException("$path is not a directory")

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/MethodsConverter.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/MethodsConverter.kt
@@ -3,7 +3,7 @@ package com.fourlastor.pickle
 import cucumber.runtime.model.CucumberScenario
 import cucumber.runtime.model.CucumberScenarioOutline
 import cucumber.runtime.model.CucumberTagStatement
-import java.util.*
+import java.util.Collections
 import javax.annotation.processing.Messager
 import javax.tools.Diagnostic
 
@@ -67,9 +67,9 @@ class MethodsConverter(
     }
 }
 
-class UnsupportedStatementException(type: String) : IllegalArgumentException("Statements of type \"$type\" aren't supported")
+class UnsupportedStatementException(type: String) : PickleException("Statements of type \"$type\" aren't supported")
 
-class DuplicateScenarioException(duplicateScenarios: Collection<String>) : RuntimeException("""
+class DuplicateScenarioException(duplicateScenarios: Collection<String>) : PickleException("""
     Scenarios need to have unique names.
     Duplicate scenarios:
     ${duplicateScenarios.joinToString(separator = "\n") { "> $it" }}

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/PickleException.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/PickleException.kt
@@ -1,0 +1,3 @@
+package com.fourlastor.pickle
+
+open class PickleException(message: String) : RuntimeException(message)

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
@@ -1,10 +1,8 @@
 package com.fourlastor.pickle
 
-import javax.annotation.processing.AbstractProcessor
-import javax.annotation.processing.Messager
-import javax.annotation.processing.RoundEnvironment
-import javax.annotation.processing.SupportedAnnotationTypes
-import javax.annotation.processing.SupportedSourceVersion
+import java.io.PrintWriter
+import java.io.StringWriter
+import javax.annotation.processing.*
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.tools.Diagnostic
@@ -34,9 +32,16 @@ class PickleProcessor : AbstractProcessor() {
             }
         } catch (exception: PickleException) {
             processingEnv.messager.error("Pickle Error:\n${exception.message}\n")
+        } catch (exception: Exception) {
+            processingEnv.messager.error("Pickle Error:\n${exception.message}\n${exception.getStrackTraceAsString()}\n")
         } finally {
             return false
         }
+    }
+
+    private fun Exception.getStrackTraceAsString() = StringWriter().let {
+        printStackTrace(PrintWriter(it))
+        it.toString()
     }
 
     private fun Options.createClassConverter(roundEnv: RoundEnvironment, messager: Messager): ClassConverter {

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/PickleProcessor.kt
@@ -32,7 +32,7 @@ class PickleProcessor : AbstractProcessor() {
                         .map { generator.generate(it) }
                         .forEach { writer.write(it) }
             }
-        } catch (exception: Exception) {
+        } catch (exception: PickleException) {
             processingEnv.messager.error("""
                 Pickle Error:
                 ${exception.message}

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/StatementConverter.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/StatementConverter.kt
@@ -78,7 +78,7 @@ class StepDefinitionArgumentsMismatchException(stepName: String, element: Execut
     > Step implementation: ${element.enclosingElement}.$element
 """.trimIndent())
 
-class AmbiguousStepDefinitionException(stepName: String, matching: List<Regex>) : RuntimeException("""
+class AmbiguousStepDefinitionException(stepName: String, matching: List<Regex>) : PickleException("""
     Multiple step implementations matched.
     > Step definition: "$stepName"
     > Step implementation with regexes:

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/StatementConverter.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/StatementConverter.kt
@@ -66,7 +66,7 @@ private fun RoundEnvironment.getStepDefinitions(): List<StepDefinition> {
 
 private data class StepDefinition(val element: ExecutableElement, val regex: Regex)
 
-class StepDefinitionArgumentsMismatchException(stepName: String, element: ExecutableElement) : RuntimeException("""
+class StepDefinitionArgumentsMismatchException(stepName: String, element: ExecutableElement) : PickleException("""
     Step definition argument mismatch.
     > Step definition: "$stepName"
     > Step implementation: ${element.enclosingElement}.$element

--- a/pickle-processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/StatementHooksCreator.kt
@@ -32,7 +32,7 @@ class StatementHooksCreator(private val roundEnv: RoundEnvironment) {
             when (val annotation = getAnnotation(annotationType)) {
                 is Before -> annotation.order
                 is After -> annotation.order
-                else -> throw IllegalStateException("Unexpected Cucumber annotation used: $annotationType")
+                else -> throw PickleException("Unexpected Cucumber annotation used: $annotationType")
             }
 }
 


### PR DESCRIPTION
I had a case where annotation processor would fail because of an unexpected error. I think it was IndexOutOfBoundsException. And the output would only say `Pickle Error: ` with no proper stacktrace.

I believe this will actually help identify the issues in case something wrong happens internally with Pickle.