### PR TITLE
Add Ignore annotation to class level when all steps are missing

### DIFF
--- a/pickle-processor/src/main/java/com/fourlastor/pickle/ClassGenerator.kt
+++ b/pickle-processor/src/main/java/com/fourlastor/pickle/ClassGenerator.kt
@@ -19,6 +19,10 @@ class ClassGenerator {
         runWithJUnit4()
         addModifiers(Modifier.PUBLIC)
 
+        if (testClass.isAllTestsIgnored()) {
+            addAnnotation(AnnotationSpec.builder(Ignore).build())
+        }
+
         testClass.hookMethods
                 .filter { it.statements.isNotEmpty() }
                 .forEach { hook ->
@@ -57,6 +61,8 @@ class ClassGenerator {
         testClass.fields.map { it.toFieldSpec() }
                 .forEach { addField(it) }
     }
+
+    private fun TestClass.isAllTestsIgnored() = methods.all { it is IgnoredTestMethod }
 
     private fun ignore(scenarioName: String) = AnnotationSpec.builder(Ignore)
             .addMember("value", "\$S", "Missing steps for scenario \"$scenarioName\"")

--- a/pickle-processor/src/test/java/com/fourlastor/pickle/PickleTest.kt
+++ b/pickle-processor/src/test/java/com/fourlastor/pickle/PickleTest.kt
@@ -71,6 +71,28 @@ class PickleTest {
     }
 
     @Test
+    fun featureWithAllDefinedStepsMissingInNonStrictMode() {
+        val packageName = "targetForNonStrictModeAllStepsMissing"
+
+        val compilation = whenCompilingWith(
+                featuresDir,
+                packageName,
+                nonStrict
+        )
+
+        assertThat(compilation).succeeded()
+        assertThat(compilation).hadWarningContaining("Missing step definition for \"A step without parameters\"")
+        assertThat(compilation).hadWarningContaining("Missing step definition for \"A step with 1 as parameter\"")
+        assertThat(compilation).hadWarningContaining("Missing step definition for \"A step with 2 as parameter\"")
+        assertThat(compilation).hadWarningContaining("Missing step definition for \"A step without parameters\"")
+        assertThat(compilation).hadWarningContaining("Missing step definition for \"A step with 1 as parameter\"")
+        assertThat(compilation).hadWarningContaining("Missing step definition for \"A step with a as parameter\"")
+        assertThat(compilation).successfullyGeneratedTestClasses(
+                "$packageName/AFeatureWithoutBackgroundTest.java"
+        )
+    }
+
+    @Test
     fun featureWithDefinedStepsAndHooks() {
         val packageName = "targetWithHooks"
         val compilation = whenCompilingWith(

--- a/pickle-processor/src/test/resources/targetForNonStrictModeAllStepsMissing/AFeatureWithoutBackgroundTest.java
+++ b/pickle-processor/src/test/resources/targetForNonStrictModeAllStepsMissing/AFeatureWithoutBackgroundTest.java
@@ -1,0 +1,36 @@
+package targetForNonStrictModeAllStepsMissing;
+
+import android.support.test.runner.AndroidJUnit4;
+import java.lang.Throwable;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@Ignore
+public class AFeatureWithoutBackgroundTest {
+    @Test
+    @Ignore("Missing steps for scenario \"Scenario with one step, also non       alphanumeric chars _ 1!\"")
+    public void scenarioWithOneStepAlsoNonAlphanumericChars_1() throws Throwable {
+    }
+
+    @Test
+    @Ignore("Missing steps for scenario \"Scenario with two steps\"")
+    public void scenarioWithTwoSteps() throws Throwable {
+    }
+
+    @Test
+    @Ignore("Missing steps for scenario \"Scenario with steps from 2 definition files\"")
+    public void scenarioWithStepsFrom2DefinitionFiles() throws Throwable {
+    }
+
+    @Test
+    @Ignore("Missing steps for scenario \"Scenario with examples\"")
+    public void scenarioWithExamples0() throws Throwable {
+    }
+
+    @Test
+    @Ignore("Missing steps for scenario \"Scenario with examples\"")
+    public void scenarioWithExamples1() throws Throwable {
+    }
+}


### PR DESCRIPTION
In non-strict mode, using `@Ignore` annotation was a really good idea. This allows us to make use of special `Skipped` tags in IntellIJ and Android Studio and marks these tests as yellow. 

While using this, I realized that Android Test Runner spends a lot of time (1-2 sec per test) even when tests are ignored. 

This is just a little bit optimization that ignores the whole class in case all steps are missing.